### PR TITLE
Add unit tests for org.apache.ibatis.executor.loader.ResultLoaderMap

### DIFF
--- a/src/test/java/org/apache/ibatis/executor/loader/ResultLoaderMapTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/ResultLoaderMapTest.java
@@ -1,0 +1,49 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.loader;
+
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResultLoaderMapTest {
+
+  @Test
+  void hasLoaderFalse() {
+    assertFalse(new ResultLoaderMap().hasLoader("==="));
+  }
+
+  @Test
+  void loadAllNullPointerException() throws NullPointerException, SQLException {
+    new ResultLoaderMap().loadAll();
+  }
+
+  @Test
+  void loadInputNotNullOutputFalse() throws SQLException {
+    assertFalse(new ResultLoaderMap().load("]]]"));
+  }
+
+  @Test
+  void removeInputNotNullOutputVoid() {
+    new ResultLoaderMap().remove("]]]]]]]");
+  }
+
+  @Test
+  void sizeOutputZero() {
+    assertEquals(0, new ResultLoaderMap().size());
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed some gaps in the coverage of ResultLoaderMap. I've written some tests for the functions with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/products).

Hopefully these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for mybatis, I would be more than happy to look at a particular class and help you achieve a higher coverage figure.